### PR TITLE
Timeout effect

### DIFF
--- a/app/rt_tracker/routes/api.rb
+++ b/app/rt_tracker/routes/api.rb
@@ -1,6 +1,7 @@
 require 'roda'
 require 'rt_tracker/middleware/resolve'
 require 'rt_tracker/middleware/logger'
+require 'rt_tracker/middleware/timeout'
 require 'rt_tracker/middleware/timestamp'
 
 module RtTracker
@@ -8,6 +9,7 @@ module RtTracker
     class API < ::Roda
       use Middleware::Resolve
       use Middleware::Logger
+      use Middleware::Timeout
       use Middleware::Timestamp
 
       route do |r|

--- a/lib/rt_tracker/http_call.rb
+++ b/lib/rt_tracker/http_call.rb
@@ -7,6 +7,7 @@ module RtTracker
   class HTTPCall
     include ::Dry::Monads[:try, :result]
     include ::Dry::Effects.Timestamp
+    include ::Dry::Effects.Timeout(:http)
 
     METHODS = {
       get: ::Net::HTTP::Get,
@@ -38,13 +39,13 @@ module RtTracker
     def call(url:, method:, headers: EMPTY_HASH, body: Undefined, log: EMPTY_HASH, **options)
       raise ::RuntimeError, "HTTP calls in test environmnt are not allowed!" if test
       start = timestamp
-
+      byebug
       Try[*Errors] { perform(url, method, headers, body, **options) }.to_result.tap do
         log(log, start, url, method, headers, body, _1)
       end
     end
 
-    def perform(url, method, headers, body, timeout: 30, basic_auth: Undefined)
+    def perform(url, method, headers, body, timeout: self.timeout, basic_auth: Undefined)
       uri = URI(url)
 
       options = {

--- a/lib/rt_tracker/middleware/timeout.rb
+++ b/lib/rt_tracker/middleware/timeout.rb
@@ -1,0 +1,22 @@
+# auto_register: false
+
+require 'dry/effects'
+
+module RtTracker
+  module Middleware
+    class Timeout
+      include ::Dry::Effects::Handler.Timeout
+      include Import['env.test']
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        with_timeout(10.0, overridable: test) { @app.(env) }
+      rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout
+        [504, {}, ["Gateway Timeout"]]
+      end
+    end
+  end
+end

--- a/spec/http_call_spec.rb
+++ b/spec/http_call_spec.rb
@@ -69,14 +69,17 @@ RSpec.describe RtTracker::HTTPCall, :webrick do
       end
 
       error = run_server do
-        http_call.(
+        cc = http_call.(
           url: "http://localhost:#{port}/",
           method: 'post',
           timeout: 0.3,
           headers: {
             'Content-Type' => 'plain/text'
           }
-        ).failure
+        )
+        # byebug
+        cc.failure
+
       end
 
       expect(error).to be_a(Timeout::Error)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   config.include Dry::Effects::Handler.Resolve(RtTracker::App)
   config.include Dry::Effects::Handler.CurrentTime
   config.include Dry::Effects::Handler.Timestamp
+  config.include Dry::Effects::Handler.Timeout
   config.include Module.new {
     extend RSpec::SharedContext
     let(:deps) { { 'lock_backend' => LockBackend::Succeeding } }
@@ -79,9 +80,11 @@ RSpec.configure do |config|
   config.around do |ex|
     provide(deps) do
       RtTracker::TaggedLogger.() do
-        with_timestamp do
-          with_current_time do
-            ex.run
+        with_timeout(10) do
+          with_timestamp do
+            with_current_time do
+              ex.run
+            end
           end
         end
       end
@@ -90,6 +93,7 @@ RSpec.configure do |config|
 
   config.include Dry::Effects.CurrentTime
   config.include Dry::Effects.Timestamp
+  config.include Dry::Effects.Timeout(:http)
 
   config.disable_monkey_patching!
 


### PR DESCRIPTION
Не мог бы посмотреть, почему не перехватывается эффект?
При запуске теста `rspec spec/http_call_spec.rb:8`
```
Dry::Effects::Errors::UnhandledEffectError:
       Effect #<Dry::Effects::Effects::Timeout::TimeoutEffect type=:timeout name=:timeout scope=:http> not handled. Effects must be wrapped with corresponding handlers
```
